### PR TITLE
DBOps core module and engine dbops patch

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,7 @@
+RewriteEngine on
+RewriteRule ^assets/(.*)$ /assets/$1 [END]
+RewriteRule ^about$ /tally_about.php [END]
+RewriteRule ^reports$ /tally_reports.php [END]
+RewriteRule ^module_test$ /test.php [END]
+RewriteRule ^serv_info$ /phpinfo.php [END]
+RewriteRule ^(.*)$ /tally.php [END]

--- a/app.php
+++ b/app.php
@@ -77,4 +77,1241 @@ function tally_meta()
   echo "<meta name=\"application-name\" content=\"".APP_NAME."\">\n";
   echo "<meta name=\"author\" content=\"".APP_AUTHOR_NAME."\">\n";
 }
+
+// ===========================
+// = BEGIN MODULE CORE-DBOPS =
+// ===========================
+
+class CORE_DBOPS
+{
+  // @ref:CORE_DBOPS:MODE:ERROR
+  const MODE_ERROR = 0x00;
+  // @ref:CORE_DBOPS:MODE:SUCCESS
+  const MODE_SUCCESS = 0x01;
+
+  public $operation_mode;
+
+  // @param         ref:CORE_DBOPS_OPERATION:MODE   $opmode        Operation
+  // mode.
+  // @param         ref:mysqli_result               $mysqli:1      MySQLi
+  // result object.
+  // @param         ref:mysqli_stmt                 $mysqli:2      MySQLi
+  // statement object.
+  // @param         string                          $query         MySQL query
+  // string.
+  // @param:opt     Array                           $inputs        MySQL
+  // inputs.
+  // @param:opt     ref:CORE_DBOPS:MODE             $mode          Construction
+  // mode.
+  function __construct($opmode, &$mysqli, $query, $inputs = array(),
+      $mode = CORE_DBOPS::MODE_ERROR)
+  {
+    $this->operation_mode = $opmode;
+    // If constructed in an error
+    if($mode == CORE_DBOPS::MODE_ERROR)
+    {
+      // Store MySQL error
+      $this->connect_errno = $mysqli->connect_errno;
+      $this->connect_error = $mysqli->connect_error;
+
+      $this->errno = $mysqli->errno;
+      $this->error = $mysqli->error;
+      $this->error_list = $mysqli->error_list;
+      $this->sqlstate = $mysqli->sqlstate;
+
+      // Store query and inputs
+      $this->query = $query;
+      $this->inputs = $inputs;
+    }
+    // If constructed in a success
+    else
+    {
+      // Initiate property
+      $this->mysqli_result = new stdClass;
+      $this->mysqli_stmt = new stdClass;
+
+      // Store mysqli_result
+      if($mysqli instanceof mysqli_result)
+        $this->mysqli_result = &$mysqli;
+
+      // Store mysqli_stmt
+      if($mysqli instanceof mysqli_stmt)
+        $this->mysqli_stmt = &$mysqli;
+    }
+  }
+}
+
+class CORE_DBOPS_SUCCESS extends SUCCESS
+{
+  public $core_dbops;
+
+  // @param         ref:CORE_DBOPS_OPERATION:MODE   $opmode         Operation
+  // mode.
+  // @param         ref:mysqli_result               $mysqli:1       MySQLi
+  // result object.
+  // @param         ref:mysqli_stmt                 $mysqli:2       MySQLi
+  // statement object.
+  // @param         string                          $query          MySQL query
+  // string.
+  // @param:opt     Array                           $inputs         MySQL
+  // inputs.
+  // @param:opt     string                          $module         Execution
+  // module.
+  function __construct($opmode, &$mysqli, $query, $inputs = array(),
+      $module = "core-dbops")
+  {
+    parent::__construct($module);
+    $this->core_dbops = new CORE_DBOPS($opmode, $mysqli, $query, $inputs,
+        CORE_DBOPS::MODE_SUCCESS);
+  }
+}
+
+class CORE_DBOPS_ERROR extends ERROR
+{
+  // @ref:CORE_DBOPS_ERROR:ERROR:CONNECTION
+  const ERROR_CONNECTION = 0xD0;
+  // @ref:CORE_DBOPS_ERROR:ERROR:SQL
+  const ERROR_SQL = 0xD1;
+
+  public $core_dbops;
+
+  // @param         ref:CORE_DBOPS_OPERATION:MODE   $operation_mode     Operation
+  // mode.
+  // @param         ref:CORE_DBOPS_ERROR:ERROR      $error_code         Error
+  // code.
+  // @param         ref:mysqli_result               $mysqli:1           MySQLi
+  // result object.
+  // @param         ref:mysqli_stmt                 $mysqli:2           MySQLi
+  // statement object.
+  // @param         string                          $query              MySQL
+  // query string.
+  // @param:opt     Array                           $inputs             MySQL
+  // inputs.
+  // @param:opt     string                          $module             Execution
+  // module.
+  // @param:opt     Array                           $attached_errors    Errors
+  // caused by this execution.
+  function __construct($operation_mode, $error_code, $mysqli, $query,
+      $inputs = array(), $module = "core-dbops", $attached_errors = array())
+  {
+    parent::__construct($error_code, $module, $attached_errors);
+    $this->error_message = $this->__get_module_error_message($error_code);
+    $this->core_dbops = new CORE_DBOPS($operation_mode, $mysqli, $query,
+        $inputs);
+  }
+
+  private function __get_module_error_message($error_code)
+  {
+    switch($error_code)
+    {
+      case CORE_DBOPS_ERROR::ERROR_CONNECTION:
+        return "Connection error.";
+        break;
+
+      case CORE_DBOPS_ERROR::ERROR_SQL:
+        return "SQL error.";
+        break;
+    }
+  }
+}
+
+class CORE_DBOPS_COLUMN
+{
+  // @ref:CORE_DBOPS_COLUMN:TYPE:VARCHAR
+  const TYPE_VARCHAR = "VARCHAR";
+  // @ref:CORE_DBOPS_COLUMN:TYPE:TEXT
+  const TYPE_TEXT = "TEXT";
+
+  // @ref:CORE_DBOPS_COLUMN:TYPE:TINYINT
+  const TYPE_TINYINT = "TINYINT";
+  // @ref:CORE_DBOPS_COLUMN:TYPE:SMALLINT
+  const TYPE_SMALLINT = "SMALLINT";
+  // @ref:CORE_DBOPS_COLUMN:TYPE:MEDIUMINT
+  const TYPE_MEDIUMINT = "MEDIUMINT";
+  // @ref:CORE_DBOPS_COLUMN:TYPE:INT
+  const TYPE_INT = "INT";
+  // @ref:CORE_DBOPS_COLUMN:TYPE:BIGINT
+  const TYPE_BIGINT = "BIGINT";
+
+  public $column_name;
+  public $column_type;
+  public $column_length;
+
+  public $column_primary;
+  public $column_foreign;
+
+  public $column_value;
+
+  public $update_key;
+
+  // @param         string                        $name         Column name.
+  // @param         ref:CORE_DBOPS_COLUMN:TYPE    $type         Column type.
+  // @param:opt     string                        $value:1      [ref:string]
+  // value.
+  // @param:opt     int                           $value:2      [ref:int]
+  // value.
+  // @param:opt     int                           $length       Column length.
+  // @param:opt     bool                          $primary      Is column a
+  // primary key.
+  // @param:opt     bool                          $upkey        Is column an
+  // update key.
+  // @param:opt     Array                         $forkey       Foreign table
+  // and key referenced by this column. The array order is table then key.
+  function __construct($name, $type, $value = NULL, $length = 0,
+      $primary = false, $upkey = false, $forkey = array())
+  {
+    $this->column_name = $name;
+    $this->column_type = $type;
+    $this->column_length = $length;
+
+    $this->column_value = $value;
+
+    $this->column_primary = $primary;
+    $this->column_foreign = $forkey;
+
+    $this->update_key = $upkey;
+  }
+}
+
+class CORE_DBOPS_OPERATION
+{
+  // @ref:CORE_DBOPS_OPERATION:MODE:DROP
+  const MODE_DROP = 0x00;
+  // @ref:CORE_DBOPS_OPERATION:MODE:CREATE
+  const MODE_CREATE = 0x01;
+  // @ref:CORE_DBOPS_OPERATION:MODE:ALTER
+  // const MODE_ALTER = 0x02;
+  // @ref:CORE_DBOPS_OPERATION:MODE:VIEW
+  const MODE_VIEW = 0x03;
+  // @ref:CORE_DBOPS_OPERATION:MODE:TRUNCATE
+  const MODE_TRUNCATE = 0x04;
+
+  // @ref:CORE_DBOPS_OPERATION:MODE:DELETE
+  const MODE_DELETE = 0x10;
+  // @ref:CORE_DBOPS_OPERATION:MODE:INSERT
+  const MODE_INSERT = 0x11;
+  // @ref:CORE_DBOPS_OPERATION:MODE:UPDATE
+  const MODE_UPDATE = 0x12;
+  // @ref:CORE_DBOPS_OPERATION:MODE:SELECT
+  const MODE_SELECT = 0x13;
+
+  public $operation_mode;
+
+  public $table_name;
+  public $table_engine;
+  public $table_columns;
+
+  public $operation_sql_foreign_checks;
+
+  // Backwards compatibility
+  public $columns;
+
+  // @param         string                            $name         Table name.
+  // @param         ref:CORE_DBOPS_COLUMN             $columns      Table
+  // columns.
+  // @param         ref:CORE_DBOPS_OPERATION:MODE     $mode         Operation
+  // mode.
+  // @param:opt     string                            $engine       Table
+  // storage engine.
+  // @param:opt     bool                              $fc           Enable
+  // foreign checks.
+  function __construct($name, $columns, $mode, $engine = "INNODB", $fc = true)
+  {
+    $this->operation_mode = $mode;
+
+    $this->table_name = $name;
+    $this->table_engine = $engine;
+    $this->table_columns = $columns;
+
+    $this->operation_sql_foreign_checks = $fc;
+
+    // Backwards compatibility
+    $this->columns = $columns;
+  }
+}
+
+// Generates unique ID using microtime() as seed and a Mersenne Twister RNG
+// @param       int         $length       Length of the unique ID.
+// @return      string                    Generated unique ID.
+function tally_generate_id($length = 32)
+{
+  $dictionary = "0123456789"
+               ."ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+               ."abcdefghijklmnopqrstuvwxyz";
+
+  $rand = "";
+
+  for($i = 0; $i < $length; $i++)
+  {
+    $rand .= $dictionary[(mt_rand() * tally_format_asdouble_microtime())
+        % strlen($dictionary)];
+  }
+
+  return $rand;
+}
+
+// Formats microtime in a double format without losing precision
+// @return      string                    microtime
+function tally_format_asdouble_microtime()
+{
+  $mt = microtime();
+
+  $e = explode(" ", $mt);
+
+  return $e[1].substr($e[0], 1);
+}
+
+// Executes DBOps instruction
+// @param         ref:CORE_DBOPS_OPERATION      $operation      DBOps operation
+// object.
+// @return:1      ref:CORE_DBOPS_ERROR                          Error object.
+// @return:2      ref:CORE_IAM_SUCCESS                          Success object.
+function tally_dbops_execute($operation)
+{
+  $ret = new stdClass;
+
+  // Attempt to connect to MySQL server
+  g16_create_dbConn($conn);
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  $opmode = $operation->operation_mode;
+
+  // Table operation
+  if($opmode == CORE_DBOPS_OPERATION::MODE_DROP)
+    $ret = tally_drop_table($operation, $conn);
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_CREATE)
+    $ret = tally_create_table($operation, $conn);
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_VIEW)
+    $ret = tally_view_table($operation, $conn);
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_TRUNCATE)
+    $ret = tally_truncate_table($operation, $conn);
+
+  // Data operation
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_DELETE)
+    $ret = tally_delete_table($operation, $conn);
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_INSERT)
+    $ret = tally_insert_table($operation, $conn);
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_UPDATE)
+    $ret = tally_update_table($operation, $conn);
+  else if($opmode == CORE_DBOPS_OPERATION::MODE_SELECT)
+    $ret = tally_select_table($operation, $conn);
+
+  // Close connection to MySQL server
+  $conn->close();
+
+  return $ret;
+}
+
+// Deletes database table
+// @internal      true
+// @param         ref:CORE_DBOPS_OPERATION    $operation    Operation object.
+// @param:opt     ref:mysqli                  $conn         MySQLi connection
+// object.
+// @return        ref:CORE_DBOPS_ERROR                      Error object.
+// @return        ref:CORE_DBOPS_SUCCESS                    Success object.
+function tally_drop_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $ret = new stdClass;
+
+  // Create connection if not specified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag specified connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if in debug mode
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  // Build SQL query string
+  $sql = "DROP TABLE ".$operation->table_name;
+
+  // Execute the query
+  $stat = $conn->query($sql);
+
+  if(!$stat)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+    $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $conn, $sql);
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// @param         ref:CORE_DBOPS_OPERATION    $operation    Operation object.
+// @param:opt     ref:mysqli                  $conn         MySQLi connection
+// object.
+// @return:1      ref:CORE_DBOPS_ERROR                      Error object.
+// @return:2      ref:CORE_DBOPS_SUCCESS                    Success object.
+function tally_create_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $ret = new stdClass;
+
+  // Create connection if not specified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  $sql_inner_ops = array();
+  $sql_add_ops = array();
+  $sql_inner = "";
+
+  // Build inner SQL query strings
+  $columns = $operation->table_columns;
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    $sql_inner = "\t".$column->column_name." ".$column->column_type;
+
+    if($column->column_length > 0)
+      $sql_inner .= "(".$column->column_length.")";
+
+    if($column->column_primary)
+      $sql_inner .= " PRIMARY KEY";
+
+    array_push($sql_inner_ops, $sql_inner);
+
+    // Handle foreign keys
+    if(count($column->column_foreign) > 0)
+    {
+      $sql_inner = "FOREIGN KEY (".$column->column_name.") REFERENCES "
+                  .$column->column_foreign[0]."(".$column->column_foreign[1]
+                  .")";
+      array_push($sql_add_ops, $sql_inner);
+    }
+  }
+
+  $sql_inner_ops = array_merge($sql_inner_ops, $sql_add_ops);
+
+  // Build SQL query string
+  $sql = "CREATE TABLE ".$operation->table_name." (\n"
+        .implode(",\n", $sql_inner_ops)."\n"
+        .") ENGINE = ".$operation->table_engine;
+
+  $stat = $conn->query($sql);
+
+  if(!$stat)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+    $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $conn, $sql);
+
+  // Close unspecified connection
+  if($close_conn)
+    $conn->close();
+
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// Views a database table structure
+// @param         ref:CORE_DBOPS_OPERATION      $operation      Operation
+// object.
+// @param:opt     ref:mysqli                    $conn           MySQLi
+// connection object.
+// @return:1      ref:CORE_DBOPS_ERROR                          Error object.
+// @return:2      ref:CORE_DBOPS_SUCCESS                        Success object.
+function tally_view_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $ret = new stdClass;
+
+  // Create connection to MySQL server if unspecified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag specified connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if on debug mode
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  // Build SQL query string
+  $sql = "DESCRIBE ".$operation->table_name;
+
+  // Execute query
+  $stat = $conn->query($sql);
+
+  if(!$stat)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+    $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $stat, $sql);
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// Truncates a database table
+// @param         ref:CORE_DBOPS_OPERATION    $operation    Operation object.
+// @param:opt     ref:mysqli                  $conn         MySQLi connection
+// object.
+// @return:1      ref:CORE_DBOPS_ERROR                      Error object.
+// @return:2      ref:CORE_DBOPS_SUCCESS                    Success object.
+function tally_truncate_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $ret = new stdClass;
+
+  // Create connection to MySQL server if unspecified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if on debug mode
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  // Generate SQL query
+  $sql = "TRUNCATE ".$operation->table_name.";\n";
+
+  // Disable foreign checks if opted
+  if(!$operation->operation_sql_foreign_checks)
+  {
+    $sql = "SET FOREIGN_KEY_CHECKS = 0;\n".$sql
+          ."SET FOREIGN_KEY_CHECKS = 1";
+  }
+
+  // Execute the query
+  $stat = $conn->multi_query($sql);
+
+  if(!$stat)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+    $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $conn, $sql);
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// Deletes data from a database table
+// @param         ref:CORE_DBOPS_OPERATION      $operation      Operation
+// object.
+// @param:opt     ref:mysqli                    $conn           MySQLi
+// connection object.
+// @return:1      ref:CORE_DBOPS_ERROR                          Error ob.ect.
+// @return:2      ref:CORE_DBOPS_SUCCESS                        Success object.
+function tally_delete_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $ret = new stdClass;
+  $stat = false;
+
+  // Create connection if unspecified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag specified connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if on debug mode
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  $sql_inner_ops = array();
+  $sql_types = array();
+  $inputs = array();
+  $type = "";
+
+  $columns = $operation->table_columns;
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    // Convert MySQL types to PHP types
+    switch(strtoupper($column->column_type))
+    {
+      case "VARCHAR":
+      case "TEXT":
+        $type = "s";
+        break;
+
+      case "TINYINT":
+      case "SMALLINT":
+      case "MEDIUMINT":
+      case "INT":
+      case "BIGINT":
+        $type = "s";
+        break;
+    }
+
+    array_push($sql_inner_ops, $column->column_name."=?");
+    array_push($sql_types, $type);
+    array_push($inputs, $column->column_value);
+  }
+
+  // Build SQL query string
+  $sql = "DELETE FROM ".$operation->table_name." WHERE "
+        .implode(" AND ", $sql_inner_ops);
+
+  // Prepare statement
+  $stmt = $conn->prepare($sql);
+
+  // Exit if unable to prepare statement
+  if(!$stmt)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+  {
+    // Build parameters array
+    $sql_inner_ops = array();
+
+    $type = implode("", $sql_types);
+    $sql_inner_ops[] = &$type;
+
+    for($i = 0; $i < count($inputs); $i++)
+      $sql_inner_ops[] = &$inputs[$i];
+
+    // Dynamically call $stmt->bind_param()
+    call_user_func_array(array($stmt, "bind_param"), $sql_inner_ops);
+
+    // Exit if unable to bind parameters
+    if($stmt->errno != 0)
+    {
+      $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+          CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $inputs);
+    }
+    else
+    {
+      // Execute the prepared statement
+      $stat = $stmt->execute();
+
+      if(!$stat)
+      {
+        $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+            CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $inputs);
+      }
+      else
+        $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $stmt, $sql,
+            $inputs);
+    }
+  }
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// Inserts into a database table
+// @param         ref:CORE_DBOPS_OPERATION      $operation      Operation
+// object.
+// @param:opt     ref:mysqli                    $conn           MySQLi
+// connection object.
+// @return:1      ref:CORE_DBOPS_ERROR                          Error object.
+// @return:2      ref:CORE_DBOPS_SUCCESS                        Success object.
+function tally_insert_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $stat = false;
+  $ret = new stdClass;
+
+  // Create connection if unspecified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag specified connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if on debug mode
+    if(G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  $inputs = array();
+  $sql_inner_ops = array();
+  $sql_types = array();
+  $type = "";
+
+  $columns = $operation->table_columns;
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    // Convert MySQL types to PHP types
+    switch(strtoupper($column->column_type))
+    {
+      case "VARCHAR":
+      case "TEXT":
+        $type = "s";
+        break;
+
+      case "TINYINT":
+      case "SMALLINT":
+      case "MEDIUMINT":
+      case "INT":
+      case "BIGINT":
+        $type = "s";
+        break;
+    }
+
+    array_push($sql_inner_ops, $column->column_name);
+    array_push($sql_types, $type);
+    array_push($inputs, $column->column_value);
+  }
+
+  // Build statement types
+  $type = implode("", $sql_types);
+
+  // Build SQL query string
+  $sql = "INSERT INTO ".$operation->table_name." ("
+        .implode(",", $sql_inner_ops).") VALUES (";
+
+  $sql_inner_ops = array();
+  for($i = 0; $i < count($columns); $i++)
+    array_push($sql_inner_ops, "?");
+
+  $sql .= implode(",", $sql_inner_ops).")";
+
+  // Prepare statement
+  $stmt = $conn->prepare($sql);
+
+  // Exit if unable to prepare statement
+  if(!$stmt)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+  {
+    // Build parameters array
+    $sql_inner_ops = array();
+    $sql_inner_ops[] = &$type;
+    for($i = 0; $i < count($inputs); $i++)
+      $sql_inner_ops[] = &$inputs[$i];
+
+    // Dynamically call $stmt->bind_param();
+    call_user_func_array(array($stmt, "bind_param"), $sql_inner_ops);
+
+    // Exit if unable to bind to prepared statement
+    if($stmt->errno != 0)
+    {
+      $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+          CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $inputs);
+    }
+    else
+    {
+      $stat = $stmt->execute();
+
+      if(!$stat)
+      {
+        $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+            CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $inputs);
+      }
+      else
+      {
+        $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $stmt, $sql,
+            $inputs);
+      }
+    }
+  }
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// Updates an entry in a database table
+// @param         ref:CORE_DBOPS_OPERATION      $operation      Operation
+// object.
+// @param:opt     ref:mysqli                    $conn           MySQLi
+// connection object.
+// @return:1      ref:CORE_DBOPS_ERROR                          Error object.
+// @return:2      ref:CORE_DBOPS_SUCCESS                        Success object.
+function tally_update_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $stat = false;
+  $ret = new stdClass;
+
+  // Create connection if unspecified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag specified connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if on debug mode
+    if(!$stat && G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  $reusable = array();
+  $types = array();
+  $inputs = array();
+  $type = "";
+
+  // Scan for columns to update
+  $columns = $operation->table_columns;
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    // Convert MySQL types to PHP types
+    switch(strtoupper($column->column_type))
+    {
+      case "VARCHAR":
+      case "TEXT":
+        $type = "s";
+        break;
+
+      case "TINYINT":
+      case "SMALLINT":
+      case "MEDIUMINT":
+      case "INT":
+      case "BIGINT":
+        $type = "s";
+        break;
+    }
+
+    if(!$column->update_key)
+    {
+      array_push($types, $type);
+      array_push($reusable, $column->column_name." = ?");
+      array_push($inputs, $column->column_value);
+    }
+  }
+
+  // Build SQL query string
+  $sql = "UPDATE ".$operation->table_name." SET "
+        .implode(", ", $reusable)." WHERE ";
+
+  // Scan for update keys
+  $reusable = array();
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    // Convert MySQL types to PHP types
+    switch(strtoupper($column->column_type))
+    {
+      case "VARCHAR":
+      case "TEXT":
+        $type = "s";
+        break;
+
+      case "TINYINT":
+      case "SMALLINT":
+      case "MEDIUMINT":
+      case "INT":
+      case "BIGINT":
+        $type = "s";
+        break;
+    }
+
+    if($column->update_key)
+    {
+      array_push($types, $type);
+      array_push($reusable, $column->column_name." = ?");
+      array_push($inputs, $column->column_value);
+    }
+  }
+
+  // Finish building query
+  $sql .= implode(" AND ", $reusable);
+
+  // Prepare statement
+  $stmt = $conn->prepare($sql);
+
+  // Exit if unable to prepare statement
+  if($conn->errno != 0)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+  {
+    $reusable = array();
+
+    // Prepare types parameter
+    $type = implode("", $types);
+    $reusable[] = &$type;
+
+    // Prepare input parameters
+    for($i = 0; $i < count($inputs); $i++)
+      $reusable[] = &$inputs[$i];
+
+    // Dynamically call $stmt->bind_param()
+    call_user_func_array(array($stmt, "bind_param"), $reusable);
+
+    // Exit if unable to bind parameters
+    if($stmt->errno != 0)
+    {
+      $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+          CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $inputs);
+    }
+    else
+    {
+      // Execute prepared statement
+      $stat = $stmt->execute();
+
+      if(!$stat)
+      {
+        $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+            CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $inputs);
+      }
+      else
+      {
+        $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $stat, $sql,
+            $inputs);
+      }
+    }
+  }
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+function tally_select_table($operation, $conn = NULL)
+{
+  $close_conn = true;
+  $stat = false;
+  $ret = new stdClass;
+
+  // Create connection if unspecified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Unflag specified connection
+  else
+    $close_conn = false;
+
+  // Exit if unable to connect to MySQL server
+  if($conn instanceof ERROR || $conn->connect_errno != 0)
+  {
+    $aerrs = array();
+    // Store $conn as an attached error if it is an instance of ERROR
+    if($conn instanceof ERROR)
+      array_push($aerrs, $conn);
+
+    // Generate error object
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_CONNECTION, $conn, "", array(), "core-dbops",
+        $aerrs);
+
+    // Print the error object if on debug mode
+    if(!$stat && G16_DEBUG)
+      var_dump($ret);
+
+    return $ret;
+  }
+
+  $reusable = array();
+  $inputs = array();
+  $types = array();
+  $type = "";
+
+  // Scan for selectors
+  $columns = $operation->table_columns;
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    // Convert MySQL types to PHP types
+    switch(strtoupper($column->column_type))
+    {
+      case "VARCHAR":
+      case "TEXT":
+        $type = "s";
+        break;
+
+      case "TINYINT":
+      case "SMALLINT":
+      case "MEDIUMINT":
+      case "INT":
+      case "BIGINT":
+        $type = "s";
+        break;
+    }
+
+    if(!$column->update_key)
+      array_push($reusable, $column->column_name);
+  }
+
+  // Start building query
+  $sql = "SELECT ".implode(", ", $reusable)." FROM ".$operation->table_name;
+
+  // Scan for keys
+  $reusable = array();
+  for($i = 0; $i < count($columns); $i++)
+  {
+    $column = $columns[$i];
+
+    // Convert MySQL types to PHP types
+    switch(strtoupper($column->column_type))
+    {
+      case "VARCHAR":
+      case "TEXT":
+        $type = "s";
+        break;
+
+      case "TINYINT":
+      case "SMALLINT":
+      case "MEDIUMINT":
+      case "INT":
+      case "BIGINT":
+        $type = "s";
+        break;
+    }
+
+    if($column->update_key)
+    {
+      array_push($types, $type);
+      array_push($reusable, $column->column_name." = ?");
+      array_push($inputs, $column->column_value);
+    }
+  }
+
+  // Finish building query
+  $sql .= " WHERE ".implode(" AND ", $reusable);
+
+  // Prepare statement
+  $stmt = $conn->prepare($sql);
+
+  // Exit if unable to prepare statement
+  if($conn->errno != 0)
+  {
+    $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+        CORE_DBOPS_ERROR::ERROR_SQL, $conn, $sql);
+  }
+  else
+  {
+    $reusable = array();
+
+    // Prepare types parameter
+    $type = implode("", $types);
+    $reusable[] = &$type;
+
+    // Prepare input parameters
+    for($i = 0; $i < count($inputs); $i++)
+      $reusable[] = &$inputs[$i];
+
+    // Dynamically call $stmt->bind_param()
+    call_user_func_array(array($stmt, "bind_param"), $reusable);
+
+    // Exit if unable to bind parameters
+    if($stmt->errno != 0)
+    {
+      $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+          CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $input);
+    }
+    else
+    {
+      // Execute prepared statement
+      $stat = $stmt->execute();
+
+      if(!$stat)
+      {
+        $ret = new CORE_DBOPS_ERROR($operation->operation_mode,
+            CORE_DBOPS_ERROR::ERROR_SQL, $stmt, $sql, $input);
+      }
+      else
+      {
+        $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode,
+            $stmt->get_result(), $sql, $inputs);
+      }
+    }
+  }
+
+  // Close flagged connection
+  if($close_conn)
+    $conn->close();
+
+  // Print the error object if on debug mode
+  if(!$stat && G16_DEBUG)
+    var_dump($ret);
+
+  return $ret;
+}
+
+// ===========================
+// =  END MODULE CORE-DBOPS  =
+// ===========================
 ?>

--- a/g16_config.php
+++ b/g16_config.php
@@ -45,13 +45,13 @@ const OPT_SHOW_LICENSE_ON_FOOTER = true;
 // ===================
 
 // Change this to true if you want to use the engine's database module.
-const OPT_USE_DATABASE = false;
+const OPT_USE_DATABASE = true;
 
-const OPT_DB_HOSTNAME   = "localhost";
-const OPT_DB_USERNAME   = "username";
-const OPT_DB_PASSWORD   = "password";
-const OPT_DB_DBNAME     = "g16_engine";
-const OPT_DB_TBLPREFIX  = "g16_engine_";
+const OPT_DB_HOSTNAME   = "mysql";
+const OPT_DB_USERNAME   = "tally";
+const OPT_DB_PASSWORD   = "oIGdmn8vHa40TqBt";
+const OPT_DB_DBNAME     = "tally";
+const OPT_DB_TBLPREFIX  = "tally_";
 
 // =========================
 // = Editable Engine Flags =

--- a/g16_core.php
+++ b/g16_core.php
@@ -776,4 +776,236 @@ function g16_create_dbConn(&$conn)
 
   return true;
 }
+
+// Creates database table
+// @param         string          $tblName      Table name. It will be appended
+// to the prefix configured on `g16_config.php`.
+// @param         string          $tblObjects   Table objects. Structure:
+// ```
+// [
+//    [
+//      "column" => <column name>,
+//      "type" => <column type>,
+//      "length" => <0=no maximum length|any int maximum>,
+//      "primary" => <true|false>
+//    ]
+// ]
+// ```
+// Example:
+// ```
+// [
+//    [
+//        "column" => "id",
+//        "type" => "varchar",
+//        "length" => 32,
+//        "primary" => true
+//    ],
+//    [
+//        "column" => "user_id",
+//        "type" => "varchar",
+//        "length" => 32,
+//        "primary" => false
+//    ]
+// ]
+// ```
+// @param:opt     class:mysqli    $conn         MySQLi object. If not
+// specified, the object will be created and destroyed during table creation.
+// It is recommended to specify a MySQLi object if using this function in a
+// loop.
+// @return        Array                         Table creation status.
+// Structure:
+// ```
+// [
+//    bool      "status",
+//    int       "errno",
+//    string    "error",
+//    string[]  "error_list"
+// ]
+// ```
+function g16_create_table($tblName, $tblObjects, $engine = NULL, $conn = NULL)
+{
+  // Destruction flag
+  $closeConn = true;
+  // Verify engine availability, replace with INNODB if not available
+  if(($engine == NULL || !g16_isAvailable_dbEngine($engine))
+      && g16_isAvailable_dbEngine("innodb"))
+    $engine = "INNODB";
+  // Create the connection if not specified
+  if($conn == NULL)
+    g16_create_dbConn($conn);
+  // Disable connection destroying flag
+  else
+    $closeConn = false;
+  // SQL query
+  $query = "CREATE TABLE ".$conn->escape_string(OPT_DB_TBLPREFIX.$tblName)
+          ." (\n";
+  for($i = 0; $i < count($tblObjects); $i++)
+  {
+    $tblObj = $tblObjects[$i];
+    // Verify that column and type exists and not empty
+    if(isset($tblObj["column"]) && strlen($tblObj["column"]) > 0
+        && isset($tblObj["type"]) && strlen($tblObj["type"]) > 0)
+    {
+      $query .= "\t".$conn->escape_string($tblObj["column"])." "
+               .strtoupper($tblObj["type"]);
+      // Specify the maximum length of the column if the length key exists and
+      // the value is greater than zero.
+      if(isset($tblObj["length"]) && $tblObj["length"] > 0)
+        $query .= "(".$conn->escape_string($tblObj["length"]).")";
+      // Set primary key if the key exists and the value is true
+      if(isset($tblObj["primary"]) && $tblObj["primary"])
+        $query .= " PRIMARY KEY";
+      $query .= ",\n";
+    }
+  }
+  // Strip the last "," and add a new line
+  $query = substr($query, 0, strlen($query) - 2)."\n";
+  $query .= ") ENGINE = ".$engine;
+  // Execute the query
+  $r = $conn->query($query);
+  // Return stack
+  $ret = array(
+    "status" => $r,
+    "errno" => $conn->errno,
+    "error" => $conn->error,
+    "error_list" => $conn->error_list,
+  );
+  // Destroy flagged connection.
+  if($closeConn)
+    $conn->close();
+  return $ret;
+}
+// Creates database tables
+// @param       Array       $tableObjects       Objects of tables to create.
+// Structure:
+// ```
+// [
+//  [
+//    "name": <table name>,
+//    "engine": <table engine>,
+//    "columns":
+//    [
+//      @ref:func:g16_create_table
+//    ]
+//  ]
+// ]
+// ```
+// Example:
+// ```
+// [
+//  [
+//    "name": "tbl1",
+//    "engine": "innodb",
+//    "columns":
+//    [
+//      [
+//        "column": "id",
+//        "type": "varchar",
+//        "length": 32,
+//        "primary": true
+//      ],
+//      [
+//        "column": "uid",
+//        "type": "text"
+//      ]
+//    ]
+//  ],
+//  [
+//    "name": "tbl2",
+//    "engine": "myisam",
+//    "columns":
+//    [
+//      [
+//        "column": "id",
+//        "type": "varchar",
+//        "length": 32,
+//        "primary": true
+//      ],
+//      [
+//        "column": "uid",
+//        "type": "text"
+//      ]
+//    ]
+//  ]
+// ]
+// ```
+// @return      Array                           Creation status. Structure:
+// ```
+// [
+//  bool      "connection_status",
+//  Array     "table_statuses":
+//  [
+//    string    "table_name",
+//    bool      "status",
+//    int       "errno",
+//    string    "error",
+//    string[]  "error_list"
+//  ]
+// ]
+// ```
+function g16_create_tables($tableObjects)
+{
+  $ret = array();
+  $statuses = array();
+  $conn_status = g16_create_dbConn($conn);
+  $ret = array(
+    "connection_status" => $conn_status
+  );
+  // Exit if connection cannot be made
+  if(!$conn_status)
+    return $ret;
+  // Attempts to create all table
+  for($i = 0; $i < count($tableObjects); $i++)
+  {
+    $tbl = $tableObjects[$i];
+    // Only execute if the table is named
+    if(isset($tbl["name"]) && strlen($tbl["name"]) > 0)
+    {
+      // Set the default engine parameter
+      if(!isset($tbl["engine"]))
+        $eng = NULL;
+      else
+        $eng = $tbl["engine"];
+      // Create the table
+      $stat = g16_create_table($tbl["name"], $tbl["columns"], $eng, $conn);
+      // Add table name to the returned value
+      $stat_ret = array(
+        "table_name" => $tbl["name"],
+        "status" => $stat["status"],
+        "errno" => $stat["errno"],
+        "error" => $stat["error"],
+        "error_list" => $stat["error_list"]
+      );
+      // Store the status to the statuses array
+      array_push($statuses, $stat_ret);
+    }
+  }
+  $ret["table_statuses"] = $statuses;
+  return $ret;
+}
+// Checks database engine availability
+// @param     string      $engine     The engine to check for.
+// @return    bool                    Engine availability
+function g16_isAvailable_dbEngine($engine)
+{
+  $ret = false;
+  // Connect to the database
+  $conn_stat = g16_create_dbConn($conn);
+  if(!$conn_stat)
+    return false;
+  $r = $conn->query("SHOW ENGINES");
+  // Exit if unsuccessful
+  if($r->num_rows <= 0)
+    return false;
+  // Scan for engine
+  while($rows = $r->fetch_assoc())
+  {
+    // If engine exists and supported, flag to return true
+    if(!$ret && strtolower($rows["Engine"]) == strtolower($engine)
+        && (strtolower($rows["Support"]) == "default"
+        || strtolower($rows["Support"]) == "yes"))
+      $ret = true;
+  }
+  return $ret;
+}
 ?>


### PR DESCRIPTION
`engine-dbops` is as inefficient as it could be. bdd5f130387f631a2a525c9914a693d8b3f6535c __patches__ `g16_create_dbConn()` to return one of two different classes: `SUCCESS` and `ERROR`. The state of a connection creation can easily be determined by finding the instance of the returned object. All other `engine-dbops` functions are left as it is. b792b0dc9bc8bafab69c6663b95319a029eea3cf __implements__ `core-dbops` module. Database operations are done without utilizing `engine-dbops` inefficient functions. Connections, however, are created using `g16_create_dbConn()`.