### PR TITLE
Patch missing statement object in DBOps operation with mode update

### DIFF
--- a/app.php
+++ b/app.php
@@ -1133,7 +1133,7 @@ function tally_update_table($operation, $conn = NULL)
       }
       else
       {
-        $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $stat, $sql,
+        $ret = new CORE_DBOPS_SUCCESS($operation->operation_mode, $stmt, $sql,
             $inputs);
       }
     }


### PR DESCRIPTION
`tally_dbops_execute()` with `MODE_UPDATE` fails to return `mysqli_stmt` as a part of `CORE_DBOPS_SUCCESS`. `mysqli_stmt` contains crucial information, such as `affected_rows` and `errno`.